### PR TITLE
Rename Box#title Box#type to be more accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased](https://github.com/communityfarm/the_community_farm/compare/v0.1.0...HEAD)
+
+### Changed
+
+- The `Box#title` attribute has been renamed to `Box#type` to more accurately reflect its contents.
+
 ## [0.1.0](https://github.com/communityfarm/the_community_farm/releases/tag/v0.1.0) 2016-10-01
 
 ### Added

--- a/lib/the_community_farm/organic_boxes/box.rb
+++ b/lib/the_community_farm/organic_boxes/box.rb
@@ -10,13 +10,13 @@ module TheCommunityFarm
 
       def id
         Digest::MD5.new.tap do |id|
-          id.update(title)
+          id.update(type)
           id.update(items.join("\n"))
         end.hexdigest
       end
 
-      def title
-        @title ||= noko.at_css('.lead').text.strip
+      def type
+        @type ||= noko.at_css('.lead').text.strip
       end
 
       def box_size
@@ -31,7 +31,7 @@ module TheCommunityFarm
       end
 
       def to_s
-        "#{title} #{box_size}".strip
+        "#{type} #{box_size}".strip
       end
 
       private

--- a/test/the_community_farm_test.rb
+++ b/test/the_community_farm_test.rb
@@ -20,8 +20,8 @@ describe 'TheCommunityFarm' do
         subject.id.must_equal '9a606eed390f8788a82b557b5c9cbeeb'
       end
 
-      it 'has a title' do
-        subject.title.must_equal 'Family Provider'
+      it 'has a type' do
+        subject.type.must_equal 'Family Provider'
       end
 
       it 'has a size' do


### PR DESCRIPTION
The actual title of the box (which should probably just be the name) is
the type of the box and the size of the box combined. So rename
Box#title to be Box#type to make it clearer that it doesn't give the
full picture.
