### PR TITLE
Change Box interface

### DIFF
--- a/lib/the_community_farm/organic_boxes/box.rb
+++ b/lib/the_community_farm/organic_boxes/box.rb
@@ -34,6 +34,10 @@ module TheCommunityFarm
         @items ||= item_doc.css('li').map { |li| li.text.strip }
       end
 
+      def items_sha
+        @items_sha ||= Digest::SHA1.hexdigest(items.join("\n"))
+      end
+
       def to_s
         name
       end

--- a/lib/the_community_farm/organic_boxes/box.rb
+++ b/lib/the_community_farm/organic_boxes/box.rb
@@ -8,15 +8,8 @@ module TheCommunityFarm
         @noko = noko
       end
 
-      def id
-        Digest::MD5.new.tap do |id|
-          id.update(type)
-          id.update(items.join("\n"))
-        end.hexdigest
-      end
-
       def name
-        "#{type} #{box_size}".strip
+        @name ||= "#{type} #{box_size}".strip
       end
 
       def type
@@ -44,11 +37,11 @@ module TheCommunityFarm
 
       def to_h
         {
-          id: id,
           name: name,
           type: type,
           size: box_size,
-          items: items
+          items: items,
+          items_sha: items_sha
         }
       end
 

--- a/test/the_community_farm_test.rb
+++ b/test/the_community_farm_test.rb
@@ -16,10 +16,6 @@ describe 'TheCommunityFarm' do
     describe 'Box' do
       subject { boxes.to_a[1] }
 
-      it 'has an id' do
-        subject.id.must_equal '9a606eed390f8788a82b557b5c9cbeeb'
-      end
-
       it 'has a type' do
         subject.type.must_equal 'Family Provider'
       end
@@ -60,7 +56,6 @@ describe 'TheCommunityFarm' do
 
       it 'has a #to_h method' do
         subject.to_h.must_equal(
-          id: '9a606eed390f8788a82b557b5c9cbeeb',
           name: 'Family Provider Large',
           type: 'Family Provider',
           size: 'Large',
@@ -78,7 +73,8 @@ describe 'TheCommunityFarm' do
             'Apples  (Hereford)',
             'Bananas (Ecuador)',
             'Oranges (SPA)'
-          ]
+          ],
+          items_sha: '311fc748548acb075d123faab87e50e4c64a22b8'
         )
       end
     end

--- a/test/the_community_farm_test.rb
+++ b/test/the_community_farm_test.rb
@@ -36,6 +36,10 @@ describe 'TheCommunityFarm' do
         subject.to_s.must_equal subject.name
       end
 
+      it 'has an item sha' do
+        subject.items_sha.must_equal '311fc748548acb075d123faab87e50e4c64a22b8'
+      end
+
       it 'has a list of items' do
         subject.items.must_equal [
           'Potatoes (Valor) (Somerset)',


### PR DESCRIPTION
Remove the `Box#id` method and replace it with the clearer named `Box#items_sha`. The `Box#id` method was previously returning an MD5 of the box title and the list of items joined with newlines. Rather than pretend we have a unique id for the box lets just include the items SHA so that it can be used with other data to determine the uniqueness of a box.
